### PR TITLE
Fix length limitation

### DIFF
--- a/webserver_files/root/output-single.php
+++ b/webserver_files/root/output-single.php
@@ -9,9 +9,13 @@ $filename = "../logs/backup_script-" . $date . ".log";
 <h2>Logs for backup of <?php echo $date ?></h2>
 <?php
 $fh = fopen($filename, 'r');
-$pageText = fread($fh, 25000);
-$erg = $converter->convert($pageText);
-$erg = str_replace("color: white","color: black",$erg);
-$erg = str_replace("background-color: black;","",$erg);
-echo nl2br($erg);
+if(filesize($filename) > 0) {
+  $pageText = fread($fh, filesize($filename));
+  $erg = $converter->convert($pageText);
+  $erg = str_replace("color: white","color: black",$erg);
+  $erg = str_replace("background-color: black;","",$erg);
+  echo nl2br($erg);
+} else
+  echo "Error. This log does not exist.";
+}
 ?>


### PR DESCRIPTION
Previously logs that were over 25000 bytes were cut off at this point. With this change, logs will be displayed in full length.